### PR TITLE
絶対パスでインポートできるようにする

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,6 +5,7 @@ import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
 import { fixupConfigRules } from "@eslint/compat";
 import tailwind from "eslint-plugin-tailwindcss";
 import importPlugin from "eslint-plugin-import";
+import noRelativeImportPaths from "eslint-plugin-no-relative-import-paths";
 
 export default [
   { languageOptions: { globals: globals.browser } },
@@ -12,7 +13,12 @@ export default [
   ...tseslint.configs.recommended,
   ...fixupConfigRules(pluginReactConfig),
   ...tailwind.configs["flat/recommended"],
-  { plugins: { import: importPlugin } },
+  {
+    plugins: {
+      import: importPlugin,
+      "no-relative-import-paths": noRelativeImportPaths,
+    },
+  },
   {
     rules: {
       "react/jsx-uses-react": "off",
@@ -29,6 +35,10 @@ export default [
           groups: ["builtin", "external", "internal", "sibling", "parent", "index", "object"],
           "newlines-between": "always",
         },
+      ],
+      "no-relative-import-paths/no-relative-import-paths": [
+        "error",
+        { "allowSameFolder": true, "rootDir": "src", "prefix": "~" },
       ],
     },
     settings: { react: { version: "detect" } },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-no-relative-import-paths": "^1.5.4",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.3.4",
@@ -2606,6 +2607,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.4.tgz",
+      "integrity": "sha512-2smViH7R3682NR6dwgYr8Vm7emqNP1gEjBku6DbvUy3Ef/2Fz+mhwsFjZGSixzWzazMCj4MAgIWTsHELCCDJKA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.34.1",
@@ -8295,6 +8303,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.4.tgz",
+      "integrity": "sha512-2smViH7R3682NR6dwgYr8Vm7emqNP1gEjBku6DbvUy3Ef/2Fz+mhwsFjZGSixzWzazMCj4MAgIWTsHELCCDJKA==",
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.34.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
-        "react-router-dom": "^6.10.0"
+        "react-router-dom": "^6.10.0",
+        "vite-tsconfig-paths": "^4.3.2"
       },
       "devDependencies": {
         "@eslint/compat": "^1.0.1",
@@ -2113,7 +2114,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2398,7 +2398,7 @@
       "version": "0.17.18",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
       "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -3272,6 +3272,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -4148,8 +4154,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -4167,7 +4172,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4509,7 +4514,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4557,7 +4562,7 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5022,7 +5027,7 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
       "integrity": "sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5232,7 +5237,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5641,6 +5646,26 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfck": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.3.tgz",
+      "integrity": "sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==",
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -5795,7 +5820,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6125,7 +6150,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.2.tgz",
       "integrity": "sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esbuild": "^0.17.5",
         "postcss": "^8.4.21",
@@ -6165,6 +6190,25 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }
@@ -7788,7 +7832,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -8004,7 +8047,7 @@
       "version": "0.17.18",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
       "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@esbuild/android-arm": "0.17.18",
         "@esbuild/android-arm64": "0.17.18",
@@ -8620,6 +8663,11 @@
         "slash": "^3.0.0"
       }
     },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -9196,8 +9244,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mz": {
       "version": "2.7.0",
@@ -9214,7 +9261,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true
+      "devOptional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -9440,7 +9487,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "devOptional": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -9470,7 +9517,7 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -9740,7 +9787,7 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
       "integrity": "sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -9871,7 +9918,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-      "dev": true
+      "devOptional": true
     },
     "string-width": {
       "version": "5.1.2",
@@ -10149,6 +10196,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "tsconfck": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.3.tgz",
+      "integrity": "sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==",
+      "requires": {}
+    },
     "tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10258,7 +10311,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true
+      "devOptional": true
     },
     "typescript-eslint": {
       "version": "7.11.0",
@@ -10436,12 +10489,22 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.2.tgz",
       "integrity": "sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "esbuild": "^0.17.5",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.21",
         "rollup": "^3.21.0"
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
       }
     },
     "which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.10.0"
+    "react-router-dom": "^6.10.0",
+    "vite-tsconfig-paths": "^4.3.2"
   },
   "devDependencies": {
     "@eslint/compat": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-no-relative-import-paths": "^1.5.4",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,7 +1,7 @@
 import { AppRoute } from "./AppRoute";
 import "./App.scss";
 
-import { Header } from "../shared/components/Header";
+import { Header } from "~/shared/components/Header";
 
 function App() {
   return (

--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 
-import { HelloWorld } from "../features/helloworld";
-import { PostDetailPage } from "../pages/PostDetailPage";
+import { HelloWorld } from "~/features/helloworld";
+import { PostDetailPage } from "~/pages/PostDetailPage";
 
 export const AppRoute = () => {
   return (

--- a/frontend/src/features/helloworld/HelloWorld.tsx
+++ b/frontend/src/features/helloworld/HelloWorld.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
-import { useAppDispatch, useAppSelector } from "../../shared/hooks";
-import { APIService } from "../../shared/services";
+import { useAppDispatch, useAppSelector } from "~/shared/hooks";
+import { APIService } from "~/shared/services";
 
 export function HelloWorld() {
   const { hello } = useAppSelector((state) => state.hello);

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Container } from "../shared/components/Container";
+import { Container } from "~/shared/components/Container";
 
 export function PostDetailPage() {
   return (

--- a/frontend/src/shared/hooks/index.ts
+++ b/frontend/src/shared/hooks/index.ts
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector, TypedUseSelectorHook } from "react-redux";
 
-import { RootState, AppDispatch } from "../store";
+import { RootState, AppDispatch } from "~/shared/store";
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
-import { Hello } from "../models";
+import { Hello } from "~/shared/models";
 
 const API_ENDPOINT_PATH =
   import.meta.env.VITE_API_ENDPOINT_PATH ?? "";

--- a/frontend/src/shared/store/HelloSlice.ts
+++ b/frontend/src/shared/store/HelloSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-import { Hello } from "../models";
-import { APIService } from "../services";
+import { Hello } from "~/shared/models";
+import { APIService } from "~/shared/services";
 
 export type HelloState = {
   hello?: Hello;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./src",
+    "paths": {
+      "~/*": ["*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,5 +12,5 @@ export default defineConfig({
     //   "/api": "http://localhost:9000",
     // },
   },
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->

- ファイルから別ファイルをインポートする際に絶対パスでインポートできるよう変更します。
  - `import { APIService } from "../../shared/services"` -> `import { APIService } from "~/shared/services"`
- 絶対パスで統一するためのESLintルールを追加します。

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

特になし

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

相対パスでのインポートが使われている場合にエラーが表示される

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #31 
