### PR TITLE
DB_USERとDB_PASSWORDを環境変数から拾って設定する

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -12,6 +12,9 @@ var DBHostName = "db"
 var DBPort = 3306
 var DBName = "training"
 
+var DBUser = "root"
+var DBPassword = ""
+
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {
 		HostName = v
@@ -30,5 +33,11 @@ func init() {
 	}
 	if v := os.Getenv("DB_NAME"); v != "" {
 		DBName = v
+	}
+	if v := os.Getenv("DB_USER"); v != "" {
+		DBUser = v
+	}
+	if v := os.Getenv("DB_PASSWORD"); v != "" {
+		DBPassword = v
 	}
 }

--- a/backend/internal/external/mysql.go
+++ b/backend/internal/external/mysql.go
@@ -17,7 +17,10 @@ func SetupDB() {
 	host := config.DBHostName
 	port := config.DBPort
 	dbname := config.DBName
-	dsn := fmt.Sprintf("root@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", host, port, dbname)
+	user := config.DBUser
+	password := config.DBPassword
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", user, password, host, port, dbname)
+	// dsn := fmt.Sprintf("root@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", host, port, dbname)
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
 		fmt.Println(err)

--- a/backend/internal/external/mysql.go
+++ b/backend/internal/external/mysql.go
@@ -20,7 +20,6 @@ func SetupDB() {
 	user := config.DBUser
 	password := config.DBPassword
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", user, password, host, port, dbname)
-	// dsn := fmt.Sprintf("root@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local", host, port, dbname)
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->
DB_USERとDB_PASSWORDを環境変数から拾って設定するようにした
本番環境（ECS）で動作させるのに必要

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->
- ローカルで動作するか
-  変更箇所で破壊的変更がないか

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #49 
