### PR TITLE
openapi-generator-cli実行用のnpm scriptを削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ backend/
 
 ### Frontend
 
+#### ディレクトリ構成
+
 ```
 frontend/
   index.html
@@ -128,4 +130,12 @@ frontend/
         共有Model
       store/
         Redux Store関連
+```
+
+#### openapi-generator-cliによるコード生成
+
+以下のコードを実行すると、openapi-generator-cliを使ってモデルやAPIインターフェースのコードを自動生成できます。
+
+```shell
+docker compose -f docker-compose.openapi.yml up
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint .",
     "format": "eslint . --fix",
-    "preview": "vite preview",
-    "generate": "docker-compose -f ../docker-compose.openapi.yml up"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->

フロントエンドのnpm scriptから、openapi-generator-cliでのコード生成用コマンドを削除します。
また、コード生成用のコマンドをREADMEに追加します。

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

なし

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

- READMEに書かれたコマンドでコード生成できる

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #61 
