### PR TITLE
DBのヘルスチェックが済んでからBEのコンテナを起動するように

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - ./backend:/go/src/myapp
     command: "air"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       TZ: Asia/Tokyo
   frontend:
@@ -36,6 +37,10 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=training
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 10
   prism:
     build:
       context: ./docker


### PR DESCRIPTION
## 概要

- 「バックエンドのコンテナ立ち上がってネェじゃん」があったので、その対策

<img src="https://github.com/givery-bootcamp/dena-2024-team1/assets/50935536/93105f43-5e90-43d2-a199-96d487f4179b" width="320px" />

- 具体的にはDBが立ち上がっているかのhealth checkをして、その後にBEのコンテナを起動するように

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

- BEがエラーなく立ち上がるか
- DBの起動後にBEが立ち上がっているか

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #74 
