### PR TITLE
投稿詳細画面のAPI繋ぎ込み

### DIFF
--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,34 +1,33 @@
+import { useEffect } from "react";
+
+import { useAppDispatch, useAppSelector } from "~/shared/hooks";
+import { APIService } from "~/shared/services";
 import { Container } from "~/shared/components/Container";
+import { formatDateTime } from "~/shared/utils";
 
 export function PostDetailPage() {
+  const { post } = useAppSelector((state) => state.post);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(APIService.getPost(1));
+  }, [dispatch]);
   return (
     <Container>
       <div className="mt-10 flex flex-col gap-7">
         <div className="flex flex-col gap-2">
-          <h1 className="text-xl font-bold">{mockPost.title}</h1>
+          <h1 className="text-xl font-bold">{post?.title}</h1>
           <div className="flex flex-col gap-0.5 text-sm text-gray-200">
-            <p>作成日時: {mockPost.createdAt}</p>
-            <p>更新日時: {mockPost.updatedAt}</p>
+            <p>作成日時: { formatDateTime(post?.createdAt ?? "") }</p>
+            <p>更新日時: { formatDateTime(post?.updatedAt ?? "")}</p>
           </div>
         </div>
         <hr className="border-border" />
         <div className="flex flex-col gap-3 text-lg">
-          <p className="whitespace-pre-line leading-8">{mockPost.body}</p>
-          <p className="text-right">{mockPost.user.username}</p>
+          <p className="whitespace-pre-line leading-8">{post?.body}</p>
+          <p className="text-right">{post?.userName}</p>
         </div>
       </div>
     </Container>
   );
 }
-
-// APIから以下のレスポンスが返ってくる想定
-const mockPost = {
-  id: "1",
-  title: "バナナはおやつに含まれますか？",
-  body: "来週の遠足の件で質問です。\n\nおやつは一人500円までと言われているのですが、バナナはおやつに含まれますか？\nそれとも弁当に含まれますか？",
-  createdAt: "2024/05/27 09:00",
-  updatedAt: "2024/05/27 15:30",
-  user: {
-    username: "watapon",
-  },
-};

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -10,23 +10,26 @@ export function PostDetailPage() {
   const { post } = useAppSelector((state) => state.post);
   const dispatch = useAppDispatch();
   const { postId } = useParams<{postId: string}>();
+
   useEffect(() => {
     dispatch(APIService.getPost(Number(postId)));
   }, [dispatch]);
+
+  if (!post) return <p>Loading...</p>;
   return (
     <Container>
       <div className="mt-10 flex flex-col gap-7">
         <div className="flex flex-col gap-2">
-          <h1 className="text-xl font-bold">{post?.title}</h1>
+          <h1 className="text-xl font-bold">{post.title}</h1>
           <div className="flex flex-col gap-0.5 text-sm text-gray-200">
-            <p>作成日時: { formatDateTime(post?.createdAt ?? "") }</p>
-            <p>更新日時: { formatDateTime(post?.updatedAt ?? "")}</p>
+            <p>作成日時: { formatDateTime(post.createdAt) }</p>
+            <p>更新日時: { formatDateTime(post.updatedAt)}</p>
           </div>
         </div>
         <hr className="border-border" />
         <div className="flex flex-col gap-3 text-lg">
-          <p className="whitespace-pre-line leading-8">{post?.body}</p>
-          <p className="text-right">{post?.userName}</p>
+          <p className="whitespace-pre-line leading-8">{post.body}</p>
+          <p className="text-right">{post.userName}</p>
         </div>
       </div>
     </Container>

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -22,8 +22,8 @@ export function PostDetailPage() {
         <div className="flex flex-col gap-2">
           <h1 className="text-xl font-bold">{post.title}</h1>
           <div className="flex flex-col gap-0.5 text-sm text-gray-200">
-            <p>作成日時: { formatDateTime(post.createdAt) }</p>
-            <p>更新日時: { formatDateTime(post.updatedAt)}</p>
+            <p>作成日時: {formatDateTime(post.createdAt)}</p>
+            <p>更新日時: {formatDateTime(post.updatedAt)}</p>
           </div>
         </div>
         <hr className="border-border" />

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 
 import { useAppDispatch, useAppSelector } from "~/shared/hooks";
 import { APIService } from "~/shared/services";
@@ -8,9 +9,9 @@ import { formatDateTime } from "~/shared/utils";
 export function PostDetailPage() {
   const { post } = useAppSelector((state) => state.post);
   const dispatch = useAppDispatch();
-
+  const { postId } = useParams<{postId: string}>();
   useEffect(() => {
-    dispatch(APIService.getPost(1));
+    dispatch(APIService.getPost(Number(postId)));
   }, [dispatch]);
   return (
     <Container>

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -16,3 +16,9 @@ export const getPosts = createAsyncThunk<Post[]>("getPosts", async () => {
   const response = await postApi.getAllPosts();
   return response.data;
 });
+
+export const getPost = createAsyncThunk<Post, number>("getPost", async (postId) => {
+    const postApi = new PostApi();
+    const response = await postApi.getPostById(postId);
+    return response.data;
+});

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -5,6 +5,7 @@ import { Hello } from "~/shared/models";
 
 const API_ENDPOINT_PATH =
   import.meta.env.VITE_API_ENDPOINT_PATH ?? "";
+const postApi = new PostApi();
 
 export const getHello = createAsyncThunk<Hello>("getHello", async () => {
   const response = await fetch(`${API_ENDPOINT_PATH}/hello`);
@@ -12,13 +13,11 @@ export const getHello = createAsyncThunk<Hello>("getHello", async () => {
 });
 
 export const getPosts = createAsyncThunk<Post[]>("getPosts", async () => {
-  const postApi = new PostApi();
   const response = await postApi.getAllPosts();
   return response.data;
 });
 
 export const getPost = createAsyncThunk<Post, number>("getPost", async (postId) => {
-    const postApi = new PostApi();
-    const response = await postApi.getPostById(postId);
-    return response.data;
+  const response = await postApi.getPostById(postId);
+  return response.data;
 });

--- a/frontend/src/shared/store/PostSlice.ts
+++ b/frontend/src/shared/store/PostSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+import { Post } from "~/generated";
+import { APIService } from "~/shared/services";
+
+export type PostState = {
+  post?: Post;
+};
+
+export const initialState: PostState = {};
+
+export const postSlice = createSlice({
+  name: "post",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(APIService.getPost.fulfilled, (state, action) => {
+      state.post = action.payload;
+    });
+  },
+});
+
+export default postSlice.reducer;

--- a/frontend/src/shared/store/PostsSlice.ts
+++ b/frontend/src/shared/store/PostsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-import { Post } from "~/shared/models";
+import { Post } from "~/generated";
 import { APIService } from "~/shared/services";
 
 export type PostsState = {

--- a/frontend/src/shared/store/index.ts
+++ b/frontend/src/shared/store/index.ts
@@ -2,18 +2,21 @@ import { configureStore } from "@reduxjs/toolkit";
 
 import helloReducer, { helloSlice } from "./HelloSlice";
 import postsReducer, { postsSlice } from "./PostsSlice";
+import postReducer, { postSlice } from "./PostSlice";
 
 
 export const store = configureStore({
   reducer: {
     hello: helloReducer,
     posts: postsReducer,
+    post: postReducer,
   },
 });
 
 export const actions = {
   ...helloSlice.actions,
   ...postsSlice.actions,
+  ...postSlice.actions,
 };
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->
投稿詳細画面の情報をバックエンドから取得するように変更
投稿１と投稿２でそれぞれ違う投稿詳細画面が開く
## スクリーンショット

<img width="1060" alt="スクリーンショット 2024-06-18 14 51 43" src="https://github.com/givery-bootcamp/dena-2024-team1/assets/95955238/cd468dea-62a3-4374-8bd8-9846f54cb25f">

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #25 
