### PR TITLE
投稿詳細画面に編集と削除の動線を追加する

### DIFF
--- a/frontend/src/features/posts/PostActionButtons.tsx
+++ b/frontend/src/features/posts/PostActionButtons.tsx
@@ -1,0 +1,19 @@
+import type { FC } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "~/shared/components/Button";
+
+type Props = {
+  postId: string;
+}
+
+export const PostActionButtons: FC<Props> = ({ postId }) => {
+  return (
+    <div className="flex gap-2">
+      <Link to={`/posts/${postId}/edit`}>
+        <Button>編集</Button>
+      </Link>
+      <Button variant="alert">削除</Button>
+    </div>
+  );
+};

--- a/frontend/src/features/posts/PostContent.tsx
+++ b/frontend/src/features/posts/PostContent.tsx
@@ -1,0 +1,15 @@
+import type { FC } from "react";
+
+type Props = {
+  body: string;
+  username: string;
+}
+
+export const PostContent: FC<Props> = ({ body, username }) => {
+  return (
+    <div className="flex flex-col gap-3 text-lg">
+      <p className="whitespace-pre-line leading-8">{body}</p>
+      <p className="text-right">{username}</p>
+    </div>
+  );
+};

--- a/frontend/src/features/posts/PostHeading.tsx
+++ b/frontend/src/features/posts/PostHeading.tsx
@@ -1,0 +1,19 @@
+import type { FC } from "react";
+
+type Props = {
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const PostHeading: FC<Props> = ({ title, createdAt, updatedAt }) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-xl font-bold">{title}</h1>
+      <div className="flex flex-col gap-0.5 text-sm text-gray-200">
+        <p>作成日時: {createdAt}</p>
+        <p>更新日時: {updatedAt}</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import { Button } from "~/shared/components/Button";
 import { Container } from "~/shared/components/Container";
 
@@ -20,7 +22,9 @@ export function PostDetailPage() {
           </div>
         </div>
         <div className="flex gap-2">
-          <Button>編集</Button>
+          <Link to={`/posts/${mockPost.id}/edit`}>
+            <Button>編集</Button>
+          </Link>
           <Button variant="alert">削除</Button>
         </div>
       </div>

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -4,7 +4,7 @@ import { Container } from "~/shared/components/Container";
 export function PostDetailPage() {
   return (
     <Container>
-      <div>
+      <div className="flex flex-col gap-6">
         <div className="mt-10 flex flex-col gap-7">
           <div className="flex flex-col gap-2">
             <h1 className="text-xl font-bold">{mockPost.title}</h1>
@@ -19,7 +19,7 @@ export function PostDetailPage() {
             <p className="text-right">{mockPost.user.username}</p>
           </div>
         </div>
-        <div>
+        <div className="flex gap-2">
           <Button>編集</Button>
           <Button variant="alert">削除</Button>
         </div>

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom";
-
-import { Button } from "~/shared/components/Button";
+import { PostActionButtons } from "~/features/posts/PostActionButtons";
+import { PostContent } from "~/features/posts/PostContent";
+import { PostHeading } from "~/features/posts/PostHeading";
 import { Container } from "~/shared/components/Container";
 
 export function PostDetailPage() {
@@ -8,25 +8,15 @@ export function PostDetailPage() {
     <Container>
       <div className="flex flex-col gap-6">
         <div className="mt-10 flex flex-col gap-7">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-xl font-bold">{mockPost.title}</h1>
-            <div className="flex flex-col gap-0.5 text-sm text-gray-200">
-              <p>作成日時: {mockPost.createdAt}</p>
-              <p>更新日時: {mockPost.updatedAt}</p>
-            </div>
-          </div>
+          <PostHeading
+            title={mockPost.title}
+            createdAt={mockPost.createdAt}
+            updatedAt={mockPost.updatedAt}
+          />
           <hr className="border-border" />
-          <div className="flex flex-col gap-3 text-lg">
-            <p className="whitespace-pre-line leading-8">{mockPost.body}</p>
-            <p className="text-right">{mockPost.user.username}</p>
-          </div>
+          <PostContent body={mockPost.body} username={mockPost.user.username} />
         </div>
-        <div className="flex gap-2">
-          <Link to={`/posts/${mockPost.id}/edit`}>
-            <Button>編集</Button>
-          </Link>
-          <Button variant="alert">削除</Button>
-        </div>
+        <PostActionButtons postId={mockPost.id} />
       </div>
     </Container>
   );

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,20 +1,27 @@
+import { Button } from "~/shared/components/Button";
 import { Container } from "~/shared/components/Container";
 
 export function PostDetailPage() {
   return (
     <Container>
-      <div className="mt-10 flex flex-col gap-7">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-xl font-bold">{mockPost.title}</h1>
-          <div className="flex flex-col gap-0.5 text-sm text-gray-200">
-            <p>作成日時: {mockPost.createdAt}</p>
-            <p>更新日時: {mockPost.updatedAt}</p>
+      <div>
+        <div className="mt-10 flex flex-col gap-7">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-xl font-bold">{mockPost.title}</h1>
+            <div className="flex flex-col gap-0.5 text-sm text-gray-200">
+              <p>作成日時: {mockPost.createdAt}</p>
+              <p>更新日時: {mockPost.updatedAt}</p>
+            </div>
+          </div>
+          <hr className="border-border" />
+          <div className="flex flex-col gap-3 text-lg">
+            <p className="whitespace-pre-line leading-8">{mockPost.body}</p>
+            <p className="text-right">{mockPost.user.username}</p>
           </div>
         </div>
-        <hr className="border-border" />
-        <div className="flex flex-col gap-3 text-lg">
-          <p className="whitespace-pre-line leading-8">{mockPost.body}</p>
-          <p className="text-right">{mockPost.user.username}</p>
+        <div>
+          <Button>編集</Button>
+          <Button variant="alert">削除</Button>
         </div>
       </div>
     </Container>


### PR DESCRIPTION
- blocked by: #80 

## 概要

<!-- このPRの変更を簡単に説明してください -->

投稿詳細画面に編集と削除の動線を追加します。
また、投稿詳細画面の要素をコンポーネントに分割します。

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

![image](https://github.com/givery-bootcamp/dena-2024-team1/assets/44804976/ef2c6231-fa21-47ea-b1c9-e98535b6b689)

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

- FigmaどおりのUIになっていること
- 編集ボタンをクリックすると`/posts/:postId/edit`に遷移すること

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #86 
