### PR TITLE
投稿編集画面のAPI繋ぎ込み

### DIFF
--- a/backend/internal/controller/repository/post_repository.go
+++ b/backend/internal/controller/repository/post_repository.go
@@ -59,10 +59,6 @@ func (r *PostRepository) UpdatePost(id int, title string, body string) (*entity.
 		return nil, err
 	}
 
-	// 既存の投稿に対して、引数のtitleとbodyを代入
-	// existngPost.Title = title
-	// existngPost.Body = body
-
 	// 存在していたら書き込み
 	if err := r.Conn.Model(&existngPost).Updates(model.Post{Title: title, Body: body}).Error; err != nil {
 		return nil, err

--- a/backend/internal/controller/repository/post_repository.go
+++ b/backend/internal/controller/repository/post_repository.go
@@ -142,6 +142,24 @@ func (r *PostRepository) Get(id int) (*entity.Post, error) {
 	return convertPostRepositoryModelToEntity(&post, &user), nil
 }
 
+func (r *PostRepository) DeletePost(id int) error {
+	var post model.Post
+	postResult := r.Conn.Where("id = ?", id).First(&post)
+	if postResult.Error != nil {
+		if errors.Is(postResult.Error, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return postResult.Error
+	}
+
+	postDeleteResult := r.Conn.Delete(&post)
+	if postDeleteResult.Error != nil {
+		return postDeleteResult.Error
+	}
+
+	return nil
+}
+
 func convertPostRepositoryModelToEntity(p *model.Post, u *model.User) *entity.Post {
 	return &entity.Post{
 		ID:        int(p.ID),

--- a/backend/internal/controller/repository/post_repository.go
+++ b/backend/internal/controller/repository/post_repository.go
@@ -60,11 +60,11 @@ func (r *PostRepository) UpdatePost(id int, title string, body string) (*entity.
 	}
 
 	// 既存の投稿に対して、引数のtitleとbodyを代入
-	existngPost.Title = title
-	existngPost.Body = body
+	// existngPost.Title = title
+	// existngPost.Body = body
 
 	// 存在していたら書き込み
-	if err := r.Conn.Model(&existngPost).Update("title", "body").Error; err != nil {
+	if err := r.Conn.Model(&existngPost).Updates(model.Post{Title: title, Body: body}).Error; err != nil {
 		return nil, err
 	}
 
@@ -140,24 +140,6 @@ func (r *PostRepository) Get(id int) (*entity.Post, error) {
 	}
 
 	return convertPostRepositoryModelToEntity(&post, &user), nil
-}
-
-func (r *PostRepository) DeletePost(id int) error {
-	var post model.Post
-	postResult := r.Conn.Where("id = ?", id).First(&post)
-	if postResult.Error != nil {
-		if errors.Is(postResult.Error, gorm.ErrRecordNotFound) {
-			return nil
-		}
-		return postResult.Error
-	}
-
-	postDeleteResult := r.Conn.Delete(&post)
-	if postDeleteResult.Error != nil {
-		return postDeleteResult.Error
-	}
-
-	return nil
 }
 
 func convertPostRepositoryModelToEntity(p *model.Post, u *model.User) *entity.Post {

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -13,6 +13,7 @@ export const PostEditForm = () => {
   const { postId } = useParams<{postId: string}>();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
   };

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -1,5 +1,5 @@
-import { useCallback , FormEvent , useEffect , useState } from "react";
-import { useNavigate , useParams } from "react-router-dom";
+import { useCallback, FormEvent, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useAppSelector, useAppDispatch } from "~/shared/hooks";
 import { Button } from "~/shared/components/Button";

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -13,7 +13,7 @@ export const PostEditForm = () => {
   const { postId } = useParams<{postId: string}>();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
-  
+
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
   };
@@ -22,11 +22,11 @@ export const PostEditForm = () => {
     setBody(event.target.value);
   };
 
-  if (!post) return <p>Loading...</p>;
+
   useEffect(() => {
     dispatch(APIService.getPost(Number(postId)));
-    setTitle(post.title);
-    setBody(post.body); 
+    setTitle(post?.title ?? "");
+    setBody(post?.body ?? ""); 
   }, [dispatch]);
 
   const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
@@ -46,7 +46,6 @@ export const PostEditForm = () => {
     }
 
   }, [title, body]);
-
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-8">

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -1,15 +1,73 @@
+import { useCallback , FormEvent , useEffect , useState } from "react";
+import { useNavigate , useParams } from "react-router-dom";
+
+import { useAppSelector, useAppDispatch } from "~/shared/hooks";
 import { Button } from "~/shared/components/Button";
+import { postApi } from "~/shared/services/API";
+import { APIService } from "~/shared/services";
 
 export const PostEditForm = () => {
+  const { post } = useAppSelector((state) => state.post);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const { postId } = useParams<{postId: string}>();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  console.log(title);
+  console.log(body);
+  const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+  };
+
+  const handleBodyChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setBody(event.target.value);
+  };
+
+  if (!post) return <p>Loading...</p>;
+  useEffect(() => {
+    dispatch(APIService.getPost(Number(postId)));
+    //setTitle(post.title);
+    //setBody(post.body); 
+  }, []);
+
+  const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    //console.log(title);
+    //console.log(body);
+    //console.log(postId);
+    event.preventDefault();
+    //const form = event.currentTarget;
+    //const formData = new FormData(form);
+    //const title = formData.get("title") as string;
+    //const body = formData.get("body") as string;
+    const response = await postApi.putPost(
+      parseInt(postId ?? ""),
+      {
+        title: "固定タイトル",
+        body: "固定本文",
+      },
+      { 
+        withCredentials: true,
+      },
+    );
+    //console.log(title);
+    //console.log(body);
+    //console.log(response.status);
+    if (response.status === 201) {
+      navigate("/");
+    }
+
+  }, []);
+
+
   return (
-    <form className="flex flex-col gap-8">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-8">
       <label className="flex flex-col gap-1">
         <span className="font-bold">タイトル</span>
-        <input className="h-10 rounded border border-gray-200 p-2" type="text" name="title" />
+        <input className="h-10 rounded border border-gray-200 p-2" type="text" name="title" onChange={handleTitleChange} value={title}/>
       </label>
       <label className="flex flex-col gap-1">
         <span className="font-bold">本文</span>
-        <textarea className="rounded border border-gray-200 p-2" name="body" />
+        <textarea className="rounded border border-gray-200 p-2" name="body" onChange={handleBodyChange} value={body}/>
       </label>
 
       <Button className="h-12" type="submit">更新する</Button>

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -40,7 +40,6 @@ export const PostEditForm = () => {
         withCredentials: true,
       },
     );
-    console.log(response.status);
     if (response.status === 200) {
       navigate(`/posts/${postId}`);
     }

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -13,8 +13,6 @@ export const PostEditForm = () => {
   const { postId } = useParams<{postId: string}>();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
-  console.log(title);
-  console.log(body);
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
   };
@@ -31,14 +29,7 @@ export const PostEditForm = () => {
   }, [dispatch]);
 
   const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    //console.log(title);
-    //console.log(body);
-    //console.log(postId);
     event.preventDefault();
-    //const form = event.currentTarget;
-    //const formData = new FormData(form);
-    //const title = formData.get("title") as string;
-    //const body = formData.get("body") as string;
     const response = await postApi.putPost(
       parseInt(postId ?? ""),
       {
@@ -49,11 +40,9 @@ export const PostEditForm = () => {
         withCredentials: true,
       },
     );
-    //console.log(title);
-    //console.log(body);
-    //console.log(response.status);
-    if (response.status === 201) {
-      navigate("/");
+    console.log(response.status);
+    if (response.status === 200) {
+      navigate(`/posts/${postId}`);
     }
 
   }, [title, body]);

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -26,9 +26,9 @@ export const PostEditForm = () => {
   if (!post) return <p>Loading...</p>;
   useEffect(() => {
     dispatch(APIService.getPost(Number(postId)));
-    //setTitle(post.title);
-    //setBody(post.body); 
-  }, []);
+    setTitle(post.title);
+    setBody(post.body); 
+  }, [dispatch]);
 
   const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     //console.log(title);
@@ -42,8 +42,8 @@ export const PostEditForm = () => {
     const response = await postApi.putPost(
       parseInt(postId ?? ""),
       {
-        title: "固定タイトル",
-        body: "固定本文",
+        title,
+        body,
       },
       { 
         withCredentials: true,
@@ -56,7 +56,7 @@ export const PostEditForm = () => {
       navigate("/");
     }
 
-  }, []);
+  }, [title, body]);
 
 
   return (

--- a/frontend/src/features/posts/PostEditForm.tsx
+++ b/frontend/src/features/posts/PostEditForm.tsx
@@ -31,7 +31,7 @@ export const PostEditForm = () => {
   const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const response = await postApi.putPost(
-      parseInt(postId ?? ""),
+      Number(postId),
       {
         title,
         body,


### PR DESCRIPTION
## 概要

-  投稿詳細画面から遷移した際に、フォームにタイトルと本文の初期値が入る
- 「更新する」をクリックするとタイトルと本文が更新される
- 更新された後、投稿詳細画面に遷移する
- バックエンドを一部修正
<!-- このPRの変更を簡単に説明してください -->

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点
- useEffectとuseCallbackの最後の引数がなぜ、[dispatch]と[title, body]になるかわかっていないので確認をお願いします
<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #85 
