### PR TITLE
サインアップしたあとにユーザー情報をセッションに保存

### DIFF
--- a/backend/internal/controller/handler/user_handler.go
+++ b/backend/internal/controller/handler/user_handler.go
@@ -25,7 +25,9 @@ func (h UserHandler) Signup(ctx *gin.Context) {
 		return
 	}
 
-	err := h.uu.Signup(req.Username, req.Password)
+	session := sessions.Default(ctx)
+
+	err := h.uu.Signup(session, req.Username, req.Password)
 
 	if err != nil {
 		handleError(ctx, 500, err)

--- a/backend/internal/controller/repository/user_repository.go
+++ b/backend/internal/controller/repository/user_repository.go
@@ -59,16 +59,21 @@ func convertUserRepositoryModelToEntity(ps []model.User) []entity.User {
 	return users
 }
 
-func (r *UserRepository) CreateUser(username, password string) error {
+func (r *UserRepository) CreateUser(username, password string) (entity.User, error) {
 	user := User{
 		Name:     username,
 		Password: password,
 	}
 	result := r.Conn.Create(&user)
 	if result.Error != nil {
-		return result.Error
+		return entity.User{}, result.Error
 	}
-	return nil
+	return entity.User{
+		ID:        int(user.ID),
+		Name:      user.Name,
+		CreatedAt: user.CreatedAt,
+		UpdatedAt: user.UpdatedAt,
+	}, nil
 }
 
 func (r *UserRepository) GetUserByUsername(username string) (entity.User, error) {

--- a/backend/internal/usecase/repository/user_repository.go
+++ b/backend/internal/usecase/repository/user_repository.go
@@ -8,7 +8,7 @@ import (
 
 type UserRepository interface {
 	GetAll() ([]entity.User, error)
-	CreateUser(username, password string) error
+	CreateUser(username, password string) (entity.User, error)
 	GetUserByUsername(username string) (entity.User, error)
 	SaveSession(session sessions.Session, user entity.User) error
 	GetSessionUser(session sessions.Session) (entity.User, error)

--- a/backend/internal/usecase/user_usecase.go
+++ b/backend/internal/usecase/user_usecase.go
@@ -19,7 +19,7 @@ func NewUserUsecase(ur repository.UserRepository) UserUsecase {
 	}
 }
 
-func (u UserUsecase) Signup(username, password string) error {
+func (u UserUsecase) Signup(session sessions.Session, username, password string) error {
 	if username == "" {
 		return errors.New("username is empty")
 	}
@@ -45,7 +45,20 @@ func (u UserUsecase) Signup(username, password string) error {
 		return err
 	}
 
-	return u.userRepository.CreateUser(username, password)
+	user, err = u.userRepository.CreateUser(username, password)
+
+	if err != nil {
+		return err
+	}
+
+	// セッションにユーザーを保存
+	err = u.userRepository.SaveSession(session, user)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (u UserUsecase) Signin(session sessions.Session, username, password string) error {


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->
サインアップ後にサインイン画面を挟まずサインインできるようにしたいので、バックエンドで、サインアップしたあとにもユーザー情報をセッションに保存するようにした（サインインしているかの判定にセッションにユーザー情報が保存しているかどうかの情報を利用している）

以前はサインインしたときのみユーザー情報をセッション情報を保存していた

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->
サインアップしたあとにサインイン画面を挟まずにサービスの画面に遷移するか

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #126 
