### PR TITLE
画像一覧表示画面を追加

### DIFF
--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -7,6 +7,7 @@ import { PostEditPage } from "~/pages/PostEditPage";
 import { SignInPage } from "~/pages/SignInPage";
 import { SignUpPage } from "~/pages/SignUpPage";
 import { SignOutPage } from "~/pages/SignOutPage";
+import { ImageListPage } from "~/pages/ImageListPage";
 
 export const AppRoute = () => {
   return (
@@ -17,6 +18,7 @@ export const AppRoute = () => {
       <Route path="/posts/:postId/edit" element={<PostEditPage />} />
       <Route path="/signout" element={<SignOutPage />} />
       <Route path="*" element={<Navigate to={"/"} />} />
+      <Route path="/images/list" element={<ImageListPage/>} />
     </Routes>
   );
 };

--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -17,8 +17,8 @@ export const AppRoute = () => {
       <Route path="/posts/create" element={<CreatePostPage />} />
       <Route path="/posts/:postId/edit" element={<PostEditPage />} />
       <Route path="/signout" element={<SignOutPage />} />
-      <Route path="*" element={<Navigate to={"/"} />} />
       <Route path="/images/list" element={<ImageListPage/>} />
+      <Route path="*" element={<Navigate to={"/"} />} />
     </Routes>
   );
 };

--- a/frontend/src/features/sketches/SketchItem.tsx
+++ b/frontend/src/features/sketches/SketchItem.tsx
@@ -1,0 +1,20 @@
+import { formatDateTime } from "~/shared/utils";
+import { Sketch } from "~/generated";
+
+type SketchItemProps = {sketch: Sketch};
+
+export function SketchItem({ sketch }: SketchItemProps) {
+  return(
+    <div>
+      <img src={sketch.imageUrl} alt={sketch.imageUrl} className="w-1/2"/>
+      <div>
+        <div className='text-sm font-semibold text-gray-100'>
+          {sketch.userName}
+        </div>
+        <div className='text-sm text-gray-200'>
+          更新日時: {formatDateTime(sketch.updatedAt)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sketches/SketchItem.tsx
+++ b/frontend/src/features/sketches/SketchItem.tsx
@@ -5,7 +5,7 @@ type SketchItemProps = {sketch: Sketch};
 
 export function SketchItem({ sketch }: SketchItemProps) {
   return(
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center border border-double border-gray-200">
       <img src={sketch.imageUrl} alt={sketch.imageUrl} className="w-1/2"/>
       <div>
         <div className='text-sm font-semibold text-gray-100'>

--- a/frontend/src/features/sketches/SketchItem.tsx
+++ b/frontend/src/features/sketches/SketchItem.tsx
@@ -5,7 +5,7 @@ type SketchItemProps = {sketch: Sketch};
 
 export function SketchItem({ sketch }: SketchItemProps) {
   return(
-    <div className="flex flex-col items-center border border-solid border-gray-200">
+    <div className="flex flex-col items-center border border-solid border-gray-200 py-4">
       <img src={sketch.imageUrl} alt={sketch.imageUrl} className="w-1/2"/>
       <div>
         <div className='text-sm font-semibold text-gray-100'>

--- a/frontend/src/features/sketches/SketchItem.tsx
+++ b/frontend/src/features/sketches/SketchItem.tsx
@@ -5,7 +5,7 @@ type SketchItemProps = {sketch: Sketch};
 
 export function SketchItem({ sketch }: SketchItemProps) {
   return(
-    <div className="flex flex-col items-center border border-double border-gray-200">
+    <div className="flex flex-col items-center border border-solid border-gray-200">
       <img src={sketch.imageUrl} alt={sketch.imageUrl} className="w-1/2"/>
       <div>
         <div className='text-sm font-semibold text-gray-100'>

--- a/frontend/src/features/sketches/SketchItem.tsx
+++ b/frontend/src/features/sketches/SketchItem.tsx
@@ -5,7 +5,7 @@ type SketchItemProps = {sketch: Sketch};
 
 export function SketchItem({ sketch }: SketchItemProps) {
   return(
-    <div>
+    <div className="flex flex-col items-center">
       <img src={sketch.imageUrl} alt={sketch.imageUrl} className="w-1/2"/>
       <div>
         <div className='text-sm font-semibold text-gray-100'>

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -12,7 +12,7 @@ export function ImageListPage() {
   useEffect(() => {
     dispatch(APIService.getSketches());
   }, [dispatch]);
-  console.log(sketches);
+
   
   return (
     <Container className='mt-10'>

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -4,8 +4,8 @@ import { useAppDispatch, useAppSelector } from "~/shared/hooks";
 import { APIService } from "~/shared/services";
 import { Container } from "~/shared/components/Container";
 import { SketchItem } from "~/features/sketches/SketchItem";
-import { BorderLine } from "~/shared/components/BorderLine";
-import { Sketch } from "~/generated";
+//import { BorderLine } from "~/shared/components/BorderLine";
+//import { Sketch } from "~/generated";
 
 export function ImageListPage() {
   const { sketches } = useAppSelector((state) => state.sketches);
@@ -15,34 +15,17 @@ export function ImageListPage() {
     dispatch(APIService.getSketches());
   }, [dispatch]);
   console.log(sketches);
-  if (!sketches) {
-    return <Container>loading...</Container>;
-  }
-  // 3つの要素ごとに配列を分割する関数
-  const chunkArray = (array: Sketch[], size: number): Sketch[][] => {
-    return array.reduce((acc: Sketch[][], _, index: number) => 
-      index % size === 0 ? [...acc, array.slice(index, index + size)] : acc, []);
-  };
-
-
-  // sketchesを3つの要素ごとに分割
-  const sketchesChunks = chunkArray(sketches, 3);
   
   return (
     <Container className='mt-10'>
       <h1 className='text-2xl font-bold'>画像一覧</h1>
-      {sketchesChunks.map((chunk, chunkIndex) => (
-        <Fragment key={chunkIndex}>
-          <div className="flex justify-between"> {/* ここでflexboxを使って横並びにします */}
-            {chunk.map((sketch) => (
-              <Fragment key={sketch.id}>
-                <SketchItem sketch={sketch}/>
-              </Fragment>
-            ))}
-          </div>
-          {chunkIndex < sketchesChunks.length - 1 && <BorderLine/>}
-        </Fragment>
+      <div className='grid grid-cols-3'>
+        {sketches?.map((sketch,index) => (
+          <Fragment key={index}>
+            <SketchItem sketch={sketch}/>
+          </Fragment>
       ))}
+      </div>
     </Container>
   );
 }

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -3,7 +3,7 @@ import { useEffect,Fragment } from "react";
 import { useAppDispatch, useAppSelector } from "~/shared/hooks";
 import { APIService } from "~/shared/services";
 import { Container } from "~/shared/components/Container";
-import { PostItem } from "~/features/posts/PostItem";
+import { SketchItem } from "~/features/sketches/SketchItem";
 import { BorderLine } from "~/shared/components/BorderLine";
 
 export function ImageListPage() {
@@ -17,6 +17,12 @@ export function ImageListPage() {
   return (
     <Container className='mt-10'>
       <h1 className='text-2xl font-bold'>画像一覧</h1>
+      {sketches?.map((sketch,index)=>(
+        <Fragment key={index}>
+          <SketchItem sketch={sketch}/>
+          {index === sketches.length - 1 ? null : <BorderLine/>}
+        </Fragment>
+      ))}
     </Container>
   );
 }

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -5,6 +5,7 @@ import { APIService } from "~/shared/services";
 import { Container } from "~/shared/components/Container";
 import { SketchItem } from "~/features/sketches/SketchItem";
 import { BorderLine } from "~/shared/components/BorderLine";
+import { Sketch } from "~/generated";
 
 export function ImageListPage() {
   const { sketches } = useAppSelector((state) => state.sketches);
@@ -14,13 +15,32 @@ export function ImageListPage() {
     dispatch(APIService.getSketches());
   }, [dispatch]);
   console.log(sketches);
+  if (!sketches) {
+    return <Container>loading...</Container>;
+  }
+  // 3つの要素ごとに配列を分割する関数
+  const chunkArray = (array: Sketch[], size: number): Sketch[][] => {
+    return array.reduce((acc: Sketch[][], _, index: number) => 
+      index % size === 0 ? [...acc, array.slice(index, index + size)] : acc, []);
+  };
+
+
+  // sketchesを3つの要素ごとに分割
+  const sketchesChunks = chunkArray(sketches, 3);
+  
   return (
     <Container className='mt-10'>
       <h1 className='text-2xl font-bold'>画像一覧</h1>
-      {sketches?.map((sketch,index)=>(
-        <Fragment key={index}>
-          <SketchItem sketch={sketch}/>
-          {index === sketches.length - 1 ? null : <BorderLine/>}
+      {sketchesChunks.map((chunk, chunkIndex) => (
+        <Fragment key={chunkIndex}>
+          <div className="flex justify-between"> {/* ここでflexboxを使って横並びにします */}
+            {chunk.map((sketch) => (
+              <Fragment key={sketch.id}>
+                <SketchItem sketch={sketch}/>
+              </Fragment>
+            ))}
+          </div>
+          {chunkIndex < sketchesChunks.length - 1 && <BorderLine/>}
         </Fragment>
       ))}
     </Container>

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -4,8 +4,6 @@ import { useAppDispatch, useAppSelector } from "~/shared/hooks";
 import { APIService } from "~/shared/services";
 import { Container } from "~/shared/components/Container";
 import { SketchItem } from "~/features/sketches/SketchItem";
-//import { BorderLine } from "~/shared/components/BorderLine";
-//import { Sketch } from "~/generated";
 
 export function ImageListPage() {
   const { sketches } = useAppSelector((state) => state.sketches);
@@ -18,7 +16,6 @@ export function ImageListPage() {
   
   return (
     <Container className='mt-10'>
-      <h1 className='text-2xl font-bold'>画像一覧</h1>
       <div className='grid grid-cols-3'>
         {sketches?.map((sketch,index) => (
           <Fragment key={index}>

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -16,7 +16,7 @@ export function ImageListPage() {
   
   return (
     <Container className='mt-10'>
-      <div className='grid grid-cols-3'>
+      <div className='grid grid-cols-3 gap-10'>
         {sketches?.map((sketch,index) => (
           <Fragment key={index}>
             <SketchItem sketch={sketch}/>

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -1,0 +1,27 @@
+import { useEffect,Fragment } from "react";
+
+import { useAppDispatch, useAppSelector } from "~/shared/hooks";
+import { APIService } from "~/shared/services";
+import { Container } from "~/shared/components/Container";
+import { PostItem } from "~/features/posts/PostItem";
+import { BorderLine } from "~/shared/components/BorderLine";
+
+export function ImageListPage() {
+  const { posts } = useAppSelector((state) => state.posts);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(APIService.getPosts());
+  }, [dispatch]);
+
+  return (
+    <Container className='mt-10'>
+      {posts?.map((post,index)=>(
+        <Fragment key={index}>
+          <PostItem post={post}/>
+          {index === posts.length - 1 ? null : <BorderLine/>}
+        </Fragment>
+    ))}
+    </Container>
+  );
+}

--- a/frontend/src/pages/ImageListPage.tsx
+++ b/frontend/src/pages/ImageListPage.tsx
@@ -7,21 +7,16 @@ import { PostItem } from "~/features/posts/PostItem";
 import { BorderLine } from "~/shared/components/BorderLine";
 
 export function ImageListPage() {
-  const { posts } = useAppSelector((state) => state.posts);
+  const { sketches } = useAppSelector((state) => state.sketches);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(APIService.getPosts());
+    dispatch(APIService.getSketches());
   }, [dispatch]);
-
+  console.log(sketches);
   return (
     <Container className='mt-10'>
-      {posts?.map((post,index)=>(
-        <Fragment key={index}>
-          <PostItem post={post}/>
-          {index === posts.length - 1 ? null : <BorderLine/>}
-        </Fragment>
-    ))}
+      <h1 className='text-2xl font-bold'>画像一覧</h1>
     </Container>
   );
 }

--- a/frontend/src/shared/components/Header.tsx
+++ b/frontend/src/shared/components/Header.tsx
@@ -6,6 +6,7 @@ export function Header() {
       <p className="text-white">サンプルアプリケーション</p>
       <div className="flex space-x-4">
         <Link to="/" className="text-white">Top</Link>
+        <Link to="/images/list" className="text-white">Images</Link>
         <Link to="/posts/create" className="text-white">新規投稿</Link>
         <Link to="/signout" className="text-white">Signout</Link>
       </div>

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -28,7 +28,8 @@ export const getPost = createAsyncThunk<Post, number>("getPost", async (postId) 
 });
 
 export const getSketches = createAsyncThunk<Sketch[]>("getSketches", async () => {
-  const response = await SketchApi.getAllSketches({
+  const sketchApi = new SketchApi();
+  const response = await sketchApi.getAllSketches({
     withCredentials: true,
   });
   return response.data;

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
-import { Post, PostApi } from "~/generated";
+import { Post, PostApi, Sketch, SketchApi } from "~/generated";
 import { Hello } from "~/shared/models";
 
 const API_ENDPOINT_PATH =
@@ -22,6 +22,13 @@ export const getPosts = createAsyncThunk<Post[]>("getPosts", async () => {
 
 export const getPost = createAsyncThunk<Post, number>("getPost", async (postId) => {
   const response = await postApi.getPostById(postId, {
+    withCredentials: true,
+  });
+  return response.data;
+});
+
+export const getSketches = createAsyncThunk<Sketch[]>("getSketches", async () => {
+  const response = await SketchApi.getAllSketches({
     withCredentials: true,
   });
   return response.data;

--- a/frontend/src/shared/store/SketchesSlice.ts
+++ b/frontend/src/shared/store/SketchesSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+import { Sketch } from "~/generated";
+import { APIService } from "~/shared/services";
+
+export type SketchesState = {
+  sketches?: Sketch[];
+};
+
+export const initialState: SketchesState = {};
+
+export const sketchesSlice = createSlice({
+  name: "sketches",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(APIService.getSketches.fulfilled, (state, action) => {
+      state.sketches = action.payload;
+    });
+  },
+});
+
+export default sketchesSlice.reducer;

--- a/frontend/src/shared/store/index.ts
+++ b/frontend/src/shared/store/index.ts
@@ -4,6 +4,7 @@ import helloReducer, { helloSlice } from "./HelloSlice";
 import postsReducer, { postsSlice } from "./PostsSlice";
 import sessionUserReducer, { sessionUserSlice } from "./SessionUserSlice";
 import postReducer, { postSlice } from "./PostSlice";
+import sketchesReducer, { sketchesSlice } from "./SketchesSlice";
 
 
 export const store = configureStore({
@@ -12,6 +13,7 @@ export const store = configureStore({
     posts: postsReducer,
     sessionUser: sessionUserReducer,
     post: postReducer,
+    sketches: sketchesReducer,
   },
 });
 
@@ -20,6 +22,7 @@ export const actions = {
   ...postsSlice.actions,
   ...sessionUserSlice.actions,
   ...postSlice.actions,
+  ...sketchesSlice.actions,
 };
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/mysql/sql/seed.sql
+++ b/mysql/sql/seed.sql
@@ -1,13 +1,14 @@
 DELETE FROM hello_worlds;
+DELETE FROM sketches;
+DELETE FROM posts;
+DELETE FROM users;
+
 INSERT INTO hello_worlds (lang, message) VALUES ('en', 'Hello World'), ('ja', 'こんにちは 世界');
 
-DELETE FROM users;
 INSERT INTO users (name, password) VALUES ('taro', 'password'),('hanako', 'PASSWORD');
 
-DELETE FROM posts;
 INSERT INTO posts (user_id, title, body) VALUES (1, 'test1', '質問1\n改行'),(1, 'test2', '質問2\n改行');
 
-DELETE FROM sketches;
 INSERT INTO sketches (image_name, user_id) VALUES
 ('happy.png', 1),
 ('quickMTG.png', 1),


### PR DESCRIPTION
## 概要

ヘッダーにImagesを追加
Imagesをクリックすると、画像一覧表示画面に遷移
画像一覧表示画面でバックエンドから受け取った画像を表示

<!-- このPRの変更を簡単に説明してください -->

## スクリーンショット
<img width="1078" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team1/assets/95955238/8582f99b-924f-4384-92d7-e93e2f991ac9">


<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #102 
