### PR TITLE
loadingの初期値をtrueにする

### DIFF
--- a/frontend/src/app/AuthProvider.tsx
+++ b/frontend/src/app/AuthProvider.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch, useAppSelector } from "~/shared/hooks";
 import { Header, HeaderNoAuth } from "~/shared/components/Header";
 
 export const AuthProvider = () => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const { sessionUser } = useAppSelector((state) => state.sessionUser);
   const dispatch = useAppDispatch();  
@@ -17,17 +17,22 @@ export const AuthProvider = () => {
     setLoading(true);
 
     const userApi = new UserApi();
-    const response = await userApi.getSessionUser({
-      withCredentials: true,
-    });
-
-    // 取得に成功した場合
-    if (response.status === 200) {
-        const user = response.data;
-
-        // ユーザー情報をセット
-        dispatch(sessionUserSlice.actions.setSessionUser(user));
+    try {
+      const response = await userApi.getSessionUser({
+        withCredentials: true,
+      });
+  
+      // 取得に成功した場合
+      if (response.status === 200) {
+          const user = response.data;
+  
+          // ユーザー情報をセット
+          dispatch(sessionUserSlice.actions.setSessionUser(user));
+      }
+    } catch (error) {
+      return;
     }
+    
   }, []);
 
   useEffect(() => {
@@ -36,8 +41,6 @@ export const AuthProvider = () => {
     }
 
     getSessionUser()
-    .then(() => {})
-    .catch(() => {})
     .finally(() => {
       setLoading(false);
     });


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->
フロントエンドで、サインインした状態でリロードしたとき、`/`に遷移しないようにした

結論、AuthProviderの、loadingステートの初期値をtrueにした（ミス！w）

AuthProviderでサインインしているユーザーを取得しているが、それのLoadingが終わったタイミングで、ユーザー情報が取得できているかどうかをみて、画面の振り分けをしていた

しかし、Loadingの初期値がfalseだったので、ユーザーの取得の取得が終わる前に、画面の振り分けをしてしまっていて、当然ユーザー情報はないため、`/signin`に遷移して、ユーザー取得が終わったあと、AppRouterには、`/signin`に対応するルートがないため`/`に遷移していた

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->
ローディングしたあとパスが上書きされないこと

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #127 
