### PR TITLE
ログインフォームと新規登録フォームにバリデーションを追加する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.6.0",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.7.2",
         "classnames": "^2.3.2",
@@ -15,9 +16,11 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-feather": "^2.0.10",
+        "react-hook-form": "^7.52.0",
         "react-infinite-canvas": "^1.2.7",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.10.0",
+        "valibot": "^0.35.0",
         "vite-tsconfig-paths": "^4.3.2"
       },
       "devDependencies": {
@@ -873,6 +876,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.6.0.tgz",
+      "integrity": "sha512-UBcpyOX3+RR+dNnqBd0lchXpoL8p4xC21XP8H6Meb8uve5Br1GCnmg0PcBoKKqPKgGu9GHQ/oygcmPrQhetwqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4934,6 +4946,22 @@
         "react": ">=16.8.6"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-infinite-canvas": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-infinite-canvas/-/react-infinite-canvas-1.2.7.tgz",
@@ -6303,6 +6331,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/valibot": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.35.0.tgz",
+      "integrity": "sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.2.tgz",
@@ -7151,6 +7185,12 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz",
       "integrity": "sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==",
       "dev": true
+    },
+    "@hookform/resolvers": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.6.0.tgz",
+      "integrity": "sha512-UBcpyOX3+RR+dNnqBd0lchXpoL8p4xC21XP8H6Meb8uve5Br1GCnmg0PcBoKKqPKgGu9GHQ/oygcmPrQhetwqw==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -9886,6 +9926,12 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-hook-form": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
+      "requires": {}
+    },
     "react-infinite-canvas": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-infinite-canvas/-/react-infinite-canvas-1.2.7.tgz",
@@ -10743,6 +10789,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "valibot": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.35.0.tgz",
+      "integrity": "sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww=="
     },
     "vite": {
       "version": "4.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.6.0",
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.7.2",
     "classnames": "^2.3.2",
@@ -18,9 +19,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
+    "react-hook-form": "^7.52.0",
     "react-infinite-canvas": "^1.2.7",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.10.0",
+    "valibot": "^0.35.0",
     "vite-tsconfig-paths": "^4.3.2"
   },
   "devDependencies": {

--- a/frontend/src/features/users/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm.tsx
@@ -17,7 +17,7 @@ const schema = v.object({
 });
 type Schema = v.InferOutput<typeof schema>
 
-type SignFormProps = {
+type UserAuthFormProps = {
   onSubmit: (username: string, password: string) => void;
   title: string;
   submitText: string;
@@ -25,7 +25,7 @@ type SignFormProps = {
   linkTo: string;
 }
 
-export const SignForm = ({ title, submitText, linkText, linkTo, onSubmit }: SignFormProps) => {
+export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: UserAuthFormProps) => {
   const { register, formState, handleSubmit: handleFormSubmit } = useForm<Schema>({
     resolver: valibotResolver(schema),
   });

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -7,9 +7,9 @@ import { type Schema, schema } from "./schema";
 import {
   type PageType,
   typeToButtonLabel,
-  typeToLabel,
   typeToLink,
   typeToNavigationText,
+  typeToTitle,
 } from "./mapping";
 
 import { Button } from "~/shared/components/Button";
@@ -24,7 +24,7 @@ export const UserAuthForm = ({ type, onSubmit }: UserAuthFormProps) => {
     resolver: valibotResolver(schema),
   });
 
-  const label = typeToLabel[type];
+  const title = typeToTitle[type];
   const buttonLabel = typeToButtonLabel[type];
   const link = typeToLink[type];
   const navigationText = typeToNavigationText[type];
@@ -36,7 +36,7 @@ export const UserAuthForm = ({ type, onSubmit }: UserAuthFormProps) => {
 
   return (
     <form className="mt-10 flex flex-col gap-10" onSubmit={handleFormSubmit(handleSubmit)}>
-      <h1 className="text-center text-2xl font-bold">{label}</h1>
+      <h1 className="text-center text-2xl font-bold">{title}</h1>
       <div className="flex flex-col gap-6 text-lg">
         <label className="flex flex-col gap-2 text-lg">
           <span className="font-bold">ユーザー名</span>

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -26,11 +26,8 @@ export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: 
   }, [onSubmit]);
 
   return (
-    <form className="mt-10 flex flex-col gap-7" onSubmit={handleFormSubmit(handleSubmit)}>
-      <div className="flex flex-col gap-2">
-        <h1 className="text-xl font-bold">{ title }</h1>
-      </div>
-      <hr className="border-border" />
+    <form className="mt-10 flex flex-col gap-10" onSubmit={handleFormSubmit(handleSubmit)}>
+      <h1 className="text-center text-2xl font-bold">{title}</h1>
       <div className="flex flex-col gap-6 text-lg">
         <label className="flex flex-col gap-2 text-lg">
           <span className="font-bold">ユーザー名</span>

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -42,14 +42,22 @@ export const UserAuthForm = ({ type, onSubmit }: UserAuthFormProps) => {
           <span className="font-bold">ユーザー名</span>
           <div className="flex flex-col gap-1">
             <input className="border border-border p-2" type="text" {...register("username")} />
-            {formState.errors.username && <span className="text-sm font-semibold text-alert">{formState.errors.username.message}</span>}
+            {formState.errors.username && (
+              <span className="text-sm font-semibold text-alert">
+                {formState.errors.username.message}
+              </span>
+            )}
           </div>
         </label>
         <label className="flex flex-col gap-2 text-lg">
           <span className="font-bold">パスワード</span>
           <div className="flex flex-col gap-1">
             <input className="border border-border p-2" type="password" {...register("password")} />
-            {formState.errors.password && <span className="text-sm font-semibold text-alert">{formState.errors.password.message}</span>}
+            {formState.errors.password && (
+              <span className="text-sm font-semibold text-alert">
+                {formState.errors.password.message}
+              </span>
+            )}
           </div>
         </label>
         <Button type="submit">{buttonLabel}</Button>

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -5,6 +5,8 @@ import { Link } from "react-router-dom";
 
 import { type Schema, schema } from "./schema";
 
+import { Button } from "~/shared/components/Button";
+
 type UserAuthFormProps = {
   onSubmit: (username: string, password: string) => void;
   title: string;
@@ -29,18 +31,22 @@ export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: 
         <h1 className="text-xl font-bold">{ title }</h1>
       </div>
       <hr className="border-border" />
-      <div className="flex flex-col gap-3 text-lg">
+      <div className="flex flex-col gap-6 text-lg">
         <label className="flex flex-col gap-2 text-lg">
-          <span>ユーザー名</span>
-          <input className="border border-border p-2" type="text" {...register("username")} />
-          {formState.errors.username && <span className="text-sm text-alert">{formState.errors.username.message}</span>}
+          <span className="font-bold">ユーザー名</span>
+          <div className="flex flex-col gap-1">
+            <input className="border border-border p-2" type="text" {...register("username")} />
+            {formState.errors.username && <span className="text-sm font-semibold text-alert">{formState.errors.username.message}</span>}
+          </div>
         </label>
         <label className="flex flex-col gap-2 text-lg">
-          <span>パスワード</span>
-          <input className="border border-border p-2" type="password" {...register("password")} />
-          {formState.errors.password && <span className="text-sm text-alert">{formState.errors.password.message}</span>}
+          <span className="font-bold">パスワード</span>
+          <div className="flex flex-col gap-1">
+            <input className="border border-border p-2" type="password" {...register("password")} />
+            {formState.errors.password && <span className="text-sm font-semibold text-alert">{formState.errors.password.message}</span>}
+          </div>
         </label>
-        <button className="mt-10 rounded-md bg-primary p-2 text-white" type="submit">{submitText}</button>
+        <Button type="submit">{submitText}</Button>
       </div>
       <div>
         <Link to={linkTo} className="underline">{linkText}</Link>

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -4,21 +4,30 @@ import { type SubmitHandler, useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 
 import { type Schema, schema } from "./schema";
+import {
+  type PageType,
+  typeToButtonLabel,
+  typeToLabel,
+  typeToLink,
+  typeToNavigationText,
+} from "./mapping";
 
 import { Button } from "~/shared/components/Button";
 
 type UserAuthFormProps = {
+  type: PageType;
   onSubmit: (username: string, password: string) => void;
-  title: string;
-  submitText: string;
-  linkText: string;
-  linkTo: string;
 }
 
-export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: UserAuthFormProps) => {
+export const UserAuthForm = ({ type, onSubmit }: UserAuthFormProps) => {
   const { register, formState, handleSubmit: handleFormSubmit } = useForm<Schema>({
     resolver: valibotResolver(schema),
   });
+
+  const label = typeToLabel[type];
+  const buttonLabel = typeToButtonLabel[type];
+  const link = typeToLink[type];
+  const navigationText = typeToNavigationText[type];
 
   const handleSubmit: SubmitHandler<Schema> = useCallback((data) => {
     const { username, password } = data;
@@ -27,7 +36,7 @@ export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: 
 
   return (
     <form className="mt-10 flex flex-col gap-10" onSubmit={handleFormSubmit(handleSubmit)}>
-      <h1 className="text-center text-2xl font-bold">{title}</h1>
+      <h1 className="text-center text-2xl font-bold">{label}</h1>
       <div className="flex flex-col gap-6 text-lg">
         <label className="flex flex-col gap-2 text-lg">
           <span className="font-bold">ユーザー名</span>
@@ -43,10 +52,10 @@ export const UserAuthForm = ({ title, submitText, linkText, linkTo, onSubmit }: 
             {formState.errors.password && <span className="text-sm font-semibold text-alert">{formState.errors.password.message}</span>}
           </div>
         </label>
-        <Button type="submit">{submitText}</Button>
+        <Button type="submit">{buttonLabel}</Button>
       </div>
       <div>
-        <Link to={linkTo} className="underline">{linkText}</Link>
+        <Link to={link} className="underline">{navigationText}</Link>
       </div>
     </form>
   );

--- a/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
+++ b/frontend/src/features/users/UserAuthForm/UserAuthForm.tsx
@@ -2,20 +2,8 @@ import { valibotResolver } from "@hookform/resolvers/valibot";
 import { useCallback } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
-import * as v from "valibot";
 
-const schema = v.object({
-  username: v.pipe(
-    v.string(),
-    v.nonEmpty("ユーザー名を入力してください"),
-  ),
-  password: v.pipe(
-    v.string(),
-    v.nonEmpty("パスワードを入力してください"),
-    v.minLength(8, "パスワードは8文字以上で入力してください"),
-  ),
-});
-type Schema = v.InferOutput<typeof schema>
+import { type Schema, schema } from "./schema";
 
 type UserAuthFormProps = {
   onSubmit: (username: string, password: string) => void;

--- a/frontend/src/features/users/UserAuthForm/index.ts
+++ b/frontend/src/features/users/UserAuthForm/index.ts
@@ -1,0 +1,1 @@
+export * from "./UserAuthForm";

--- a/frontend/src/features/users/UserAuthForm/mapping.ts
+++ b/frontend/src/features/users/UserAuthForm/mapping.ts
@@ -1,10 +1,10 @@
 export type PageType = "sign-in" | "sign-up";
 
-type Label = "ログイン" | "新規登録";
+type Title = "ログイン" | "新規登録";
 type PageLink = "/signin" | "/signup";
 type ButtonLabel = "ログインする" | "アカウントを作成する";
 
-export const typeToLabel: Record<PageType, Label> = {
+export const typeToTitle: Record<PageType, Title> = {
   "sign-in": "ログイン",
   "sign-up": "新規登録",
 };

--- a/frontend/src/features/users/UserAuthForm/mapping.ts
+++ b/frontend/src/features/users/UserAuthForm/mapping.ts
@@ -1,0 +1,22 @@
+export type PageType = "sign-in" | "sign-up";
+
+type Label = "ログイン" | "新規登録";
+type PageLink = "/signin" | "/signup";
+type ButtonLabel = "ログインする" | "アカウントを作成する";
+
+export const typeToLabel: Record<PageType, Label> = {
+  "sign-in": "ログイン",
+  "sign-up": "新規登録",
+};
+export const typeToButtonLabel: Record<PageType, ButtonLabel> = {
+  "sign-in": "ログインする",
+  "sign-up": "アカウントを作成する",
+};
+export const typeToLink: Record<PageType, PageLink> = {
+  "sign-in": "/signup",
+  "sign-up": "/signin",
+};
+export const typeToNavigationText: Record<PageType, string> = {
+  "sign-in": "アカウントをお持ちでない方はこちら",
+  "sign-up": "アカウントをお持ちの方はこちら",
+};

--- a/frontend/src/features/users/UserAuthForm/mapping.ts
+++ b/frontend/src/features/users/UserAuthForm/mapping.ts
@@ -1,22 +1,18 @@
 export type PageType = "sign-in" | "sign-up";
 
-type Title = "ログイン" | "新規登録";
-type PageLink = "/signin" | "/signup";
-type ButtonLabel = "ログインする" | "アカウントを作成する";
-
-export const typeToTitle: Record<PageType, Title> = {
+export const typeToTitle = {
   "sign-in": "ログイン",
   "sign-up": "新規登録",
-};
-export const typeToButtonLabel: Record<PageType, ButtonLabel> = {
+} as const;
+export const typeToButtonLabel = {
   "sign-in": "ログインする",
   "sign-up": "アカウントを作成する",
-};
-export const typeToLink: Record<PageType, PageLink> = {
+} as const;
+export const typeToLink = {
   "sign-in": "/signup",
   "sign-up": "/signin",
-};
-export const typeToNavigationText: Record<PageType, string> = {
+} as const;
+export const typeToNavigationText = {
   "sign-in": "アカウントをお持ちでない方はこちら",
   "sign-up": "アカウントをお持ちの方はこちら",
-};
+} as const;

--- a/frontend/src/features/users/UserAuthForm/schema.ts
+++ b/frontend/src/features/users/UserAuthForm/schema.ts
@@ -1,0 +1,15 @@
+import * as v from "valibot";
+
+export const schema = v.object({
+  username: v.pipe(
+    v.string(),
+    v.nonEmpty("ユーザー名を入力してください"),
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty("パスワードを入力してください"),
+    v.minLength(8, "パスワードは8文字以上で入力してください"),
+  ),
+});
+
+export type Schema = v.InferOutput<typeof schema>

--- a/frontend/src/features/users/UserAuthForm/schema.ts
+++ b/frontend/src/features/users/UserAuthForm/schema.ts
@@ -8,7 +8,6 @@ export const schema = v.object({
   password: v.pipe(
     v.string(),
     v.nonEmpty("パスワードを入力してください"),
-    v.minLength(8, "パスワードは8文字以上で入力してください"),
   ),
 });
 

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -29,13 +29,7 @@ export const SignInPage = () => {
 
   return (
     <Container>
-      <UserAuthForm
-        onSubmit={handleSubmit}
-        title="ログイン"
-        submitText="ログイン"
-        linkText="アカウントをお持ちでない方はこちら"
-        linkTo="/signup"
-      />
+      <UserAuthForm type="sign-in" onSubmit={handleSubmit} />
     </Container>
   );
 };

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -2,9 +2,8 @@ import { useCallback } from "react";
 
 import { Container } from "~/shared/components/Container";
 import { UserApi } from "~/generated";
-import { SignForm } from "~/shared/components/SignForm";
 import { config } from "~/config/api";
-
+import { UserAuthForm } from "~/features/users/UserAuthForm";
 
 export const SignInPage = () => {
   const handleSubmit = useCallback(async (username: string, password: string) => {
@@ -30,7 +29,7 @@ export const SignInPage = () => {
 
   return (
     <Container>
-      <SignForm
+      <UserAuthForm
         onSubmit={handleSubmit}
         title="ログイン"
         submitText="ログイン"

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -2,8 +2,8 @@ import { useCallback } from "react";
 
 import { Container } from "~/shared/components/Container";
 import { UserApi } from "~/generated";
-import { SignForm } from "~/shared/components/SignForm";
 import { config } from "~/config/api";
+import { UserAuthForm } from "~/features/users/UserAuthForm";
 
 export const SignUpPage = () => {
   const handleSubmit = useCallback(async (username: string, password: string) => {
@@ -28,7 +28,7 @@ export const SignUpPage = () => {
 
   return (
     <Container>
-      <SignForm
+      <UserAuthForm
         onSubmit={handleSubmit}
         title="新規登録"
         submitText="アカウントを作成"

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -28,13 +28,7 @@ export const SignUpPage = () => {
 
   return (
     <Container>
-      <UserAuthForm
-        onSubmit={handleSubmit}
-        title="新規登録"
-        submitText="アカウントを作成"
-        linkText="アカウントをお持ちの方はこちら"
-        linkTo="/signin"
-      />
+      <UserAuthForm type="sign-up" onSubmit={handleSubmit} />
     </Container>
   );
 };

--- a/frontend/src/shared/components/SignForm.tsx
+++ b/frontend/src/shared/components/SignForm.tsx
@@ -1,5 +1,21 @@
-import { useCallback, FormEvent } from "react";
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { useCallback } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
+import * as v from "valibot";
+
+const schema = v.object({
+  username: v.pipe(
+    v.string(),
+    v.nonEmpty("ユーザー名を入力してください"),
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty("パスワードを入力してください"),
+    v.minLength(8, "パスワードは8文字以上で入力してください"),
+  ),
+});
+type Schema = v.InferOutput<typeof schema>
 
 type SignFormProps = {
   onSubmit: (username: string, password: string) => void;
@@ -9,33 +25,30 @@ type SignFormProps = {
   linkTo: string;
 }
 
-
 export const SignForm = (props: SignFormProps) => {
+  const { register, handleSubmit: handleFormSubmit } = useForm<Schema>({
+    resolver: valibotResolver(schema),
+  });
   const { onSubmit } = props; 
 
-  const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const formData = new FormData(form);
-    const username = formData.get("username") as string;
-    const password = formData.get("password") as string;
-
+  const handleSubmit: SubmitHandler<Schema> = useCallback((data) => {
+    const { username, password } = data;
     onSubmit(username, password);
   }, [onSubmit]);
 
   const { title, submitText, linkText, linkTo } = props;
 
   return (
-    <form className="mt-10 flex flex-col gap-7" onSubmit={handleSubmit}>
+    <form className="mt-10 flex flex-col gap-7" onSubmit={handleFormSubmit(handleSubmit)}>
       <div className="flex flex-col gap-2">
         <h1 className="text-xl font-bold">{ title }</h1>
       </div>
       <hr className="border-border" />
       <div className="flex flex-col gap-3 text-lg">
         <label className="text-lg" htmlFor="username">ユーザー名</label>
-        <input className="border border-border p-2" type="text" id="username" name="username" />
+        <input className="border border-border p-2" type="text" id="username" {...register("username")} />
         <label className="text-lg" htmlFor="password">パスワード</label>
-        <input className="border border-border p-2" type="password" id="password" name="password" />
+        <input className="border border-border p-2" type="password" id="password" {...register("password")} />
         <button className="mt-10 rounded-md bg-primary p-2 text-white" type="submit">{submitText}</button>
       </div>
       <div>

--- a/frontend/src/shared/components/SignForm.tsx
+++ b/frontend/src/shared/components/SignForm.tsx
@@ -42,10 +42,14 @@ export const SignForm = ({ title, submitText, linkText, linkTo, onSubmit }: Sign
       </div>
       <hr className="border-border" />
       <div className="flex flex-col gap-3 text-lg">
-        <label className="text-lg" htmlFor="username">ユーザー名</label>
-        <input className="border border-border p-2" type="text" id="username" {...register("username")} />
-        <label className="text-lg" htmlFor="password">パスワード</label>
-        <input className="border border-border p-2" type="password" id="password" {...register("password")} />
+        <label className="flex flex-col gap-2 text-lg">
+          <span>ユーザー名</span>
+          <input className="border border-border p-2" type="text" {...register("username")} />
+        </label>
+        <label className="flex flex-col gap-2 text-lg">
+          <span>パスワード</span>
+          <input className="border border-border p-2" type="password" {...register("password")} />
+        </label>
         <button className="mt-10 rounded-md bg-primary p-2 text-white" type="submit">{submitText}</button>
       </div>
       <div>

--- a/frontend/src/shared/components/SignForm.tsx
+++ b/frontend/src/shared/components/SignForm.tsx
@@ -26,7 +26,7 @@ type SignFormProps = {
 }
 
 export const SignForm = ({ title, submitText, linkText, linkTo, onSubmit }: SignFormProps) => {
-  const { register, handleSubmit: handleFormSubmit } = useForm<Schema>({
+  const { register, formState, handleSubmit: handleFormSubmit } = useForm<Schema>({
     resolver: valibotResolver(schema),
   });
 
@@ -45,10 +45,12 @@ export const SignForm = ({ title, submitText, linkText, linkTo, onSubmit }: Sign
         <label className="flex flex-col gap-2 text-lg">
           <span>ユーザー名</span>
           <input className="border border-border p-2" type="text" {...register("username")} />
+          {formState.errors.username && <span className="text-sm text-alert">{formState.errors.username.message}</span>}
         </label>
         <label className="flex flex-col gap-2 text-lg">
           <span>パスワード</span>
           <input className="border border-border p-2" type="password" {...register("password")} />
+          {formState.errors.password && <span className="text-sm text-alert">{formState.errors.password.message}</span>}
         </label>
         <button className="mt-10 rounded-md bg-primary p-2 text-white" type="submit">{submitText}</button>
       </div>

--- a/frontend/src/shared/components/SignForm.tsx
+++ b/frontend/src/shared/components/SignForm.tsx
@@ -25,18 +25,15 @@ type SignFormProps = {
   linkTo: string;
 }
 
-export const SignForm = (props: SignFormProps) => {
+export const SignForm = ({ title, submitText, linkText, linkTo, onSubmit }: SignFormProps) => {
   const { register, handleSubmit: handleFormSubmit } = useForm<Schema>({
     resolver: valibotResolver(schema),
   });
-  const { onSubmit } = props; 
 
   const handleSubmit: SubmitHandler<Schema> = useCallback((data) => {
     const { username, password } = data;
     onSubmit(username, password);
   }, [onSubmit]);
-
-  const { title, submitText, linkText, linkTo } = props;
 
   return (
     <form className="mt-10 flex flex-col gap-7" onSubmit={handleFormSubmit(handleSubmit)}>


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->

ログインフォームと新規登録フォームにバリデーションを追加します。
一旦空文字判定だけにしています。具体的なバリデーションは追って議論したいです。

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->
|ログイン|新規登録|
|-|-|
|![image](https://github.com/givery-bootcamp/dena-2024-team1/assets/44804976/631eca9e-d9a3-4f63-8e5a-5624a7f1f221)|![image](https://github.com/givery-bootcamp/dena-2024-team1/assets/44804976/f3c7135e-7d82-47ae-b7c7-6b05edcb76db)|

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

- ログインフォームと新規登録フォームで以下の挙動が確認できる
  - ユーザ名が空の状態でsubmitするとエラーメッセージが表示される
  - パスワードが空の状態でsubmitするとエラーメッセージが表示される

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #122 
