### PR TITLE
モーダルのオーバーレイをクリックしてもモーダルを閉じられるようにする

### DIFF
--- a/frontend/src/shared/components/Modal/Modal.tsx
+++ b/frontend/src/shared/components/Modal/Modal.tsx
@@ -17,8 +17,8 @@ export const Modal: FC<Props> = ({
 
   if (!isOpen) return null;
   return (
-    <div className="absolute left-0 top-0 z-modal flex h-screen w-screen items-center justify-center bg-[black]/40">
-      <div className="relative flex flex-col items-center justify-center gap-12 rounded-lg bg-white p-16 text-center">
+    <div className="absolute left-0 top-0 z-modal flex h-screen w-screen items-center justify-center bg-[black]/40" onClick={onClose}>
+      <div className="relative flex flex-col items-center justify-center gap-12 rounded-lg bg-white p-16 text-center" onClick={(event)=>event.stopPropagation()}>
         <button className="absolute right-2 top-2" onClick={onClose}>
           <X size={28} />
         </button>


### PR DESCRIPTION
## 概要

モーダルのオーバーレイにonClickを追加し、クリックしたときにモーダルが閉じるように変更
モーダルにstopPropagationを追加し、モーダルをクリックしてもモーダルが閉じないようにした
<!-- このPRの変更を簡単に説明してください -->

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #169 
