### PR TITLE
線の太さを変更できるようにする

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.6.0",
+        "@radix-ui/react-slider": "^1.2.0",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.7.2",
         "classnames": "^2.3.2",
@@ -1062,6 +1063,244 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
+      "integrity": "sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.2.0.tgz",
+      "integrity": "sha512-dAHCDA4/ySXROEPaRtaMV5WHL8+JB/DbtyTbJjYkY0RXmKMO2Ln8DFZhywG5/mVQ4WqHDBc8smc14yPXPqZHYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -7339,6 +7578,113 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="
+    },
+    "@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "@radix-ui/react-collection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
+      "integrity": "sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      }
+    },
+    "@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "requires": {}
+    },
+    "@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "requires": {}
+    },
+    "@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "requires": {}
+    },
+    "@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "requires": {
+        "@radix-ui/react-slot": "1.1.0"
+      }
+    },
+    "@radix-ui/react-slider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.2.0.tgz",
+      "integrity": "sha512-dAHCDA4/ySXROEPaRtaMV5WHL8+JB/DbtyTbJjYkY0RXmKMO2Ln8DFZhywG5/mVQ4WqHDBc8smc14yPXPqZHYA==",
+      "requires": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      }
+    },
+    "@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      }
+    },
+    "@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "requires": {}
+    },
+    "@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "requires": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      }
+    },
+    "@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "requires": {}
+    },
+    "@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "requires": {}
+    },
+    "@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "requires": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      }
     },
     "@reduxjs/toolkit": {
       "version": "1.9.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.6.0",
+    "@radix-ui/react-slider": "^1.2.0",
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.7.2",
     "classnames": "^2.3.2",

--- a/frontend/src/features/sketches/SketchColorPicker.tsx
+++ b/frontend/src/features/sketches/SketchColorPicker.tsx
@@ -3,11 +3,11 @@ import type { ChangeEventHandler } from "react";
 import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
 
 export const SketchColorPicker = () => {
-  const { setStrokeColor } = useStrokeSetting();
+  const { strokeColor, setStrokeColor } = useStrokeSetting();
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setStrokeColor(event.target.value);
   };
 
-  return <input className="size-8 rounded p-0.5" type="color" onChange={handleChange} />;
+  return <input className="size-8 rounded p-0.5" type="color" value={strokeColor} onChange={handleChange} />;
 };

--- a/frontend/src/features/sketches/SketchColorPicker.tsx
+++ b/frontend/src/features/sketches/SketchColorPicker.tsx
@@ -1,9 +1,9 @@
 import type { ChangeEventHandler } from "react";
 
-import { useColorPicker } from "~/shared/hooks/useColorPicker";
+import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
 
 export const SketchColorPicker = () => {
-  const { setStrokeColor } = useColorPicker();
+  const { setStrokeColor } = useStrokeSetting();
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setStrokeColor(event.target.value);

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -2,7 +2,12 @@ import type { FC, ReactNode } from "react";
 
 import { SketchColorPicker } from "./SketchColorPicker";
 
+import { Input } from "~/shared/components/Input";
+import { useColorPicker } from "~/shared/hooks/useColorPicker";
+
 export const SketchTool = () => {
+  const { strokeWidth, setStrokeWidth } = useColorPicker();
+
   return (
     <div className="flex w-56 flex-col gap-8">
       <h5 className="text-lg font-bold">お絵描きツール</h5>
@@ -13,7 +18,7 @@ export const SketchTool = () => {
         </Section>
         <Section>
           <SectionTitle>線の太さ</SectionTitle>
-          <p className="text-sm font-semibold">Coming soon...</p>
+          <Input className="w-full" type="number" value={strokeWidth} onChange={(event) => setStrokeWidth(Number(event.target.value))} />
         </Section>
       </div>
     </div>

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -1,19 +1,12 @@
-import type { ChangeEventHandler, FC, ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 
 import { SketchColorPicker } from "./SketchColorPicker";
 
-import { Input } from "~/shared/components/Input";
 import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
+import { Slider } from "~/shared/components/Slider";
 
 export const SketchTool = () => {
-  const { strokeWidth, setStrokeWidth } = useStrokeSetting();
-
-  const handleStorkeWidthChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    // 太さは1未満にはできない
-    const value = Math.max(1, Number(event.target.value));
-
-    setStrokeWidth(value);
-  };
+  const { setStrokeWidth } = useStrokeSetting();
 
   return (
     <div className="flex w-56 flex-col gap-8">
@@ -25,11 +18,10 @@ export const SketchTool = () => {
         </Section>
         <Section>
           <SectionTitle>線の太さ</SectionTitle>
-          <Input
-            className="w-full"
-            type="number"
-            value={strokeWidth}
-            onChange={handleStorkeWidthChange}
+          <Slider
+            min={1}
+            max={10}
+            onValueChange={(value) => setStrokeWidth(value[0])}
           />
         </Section>
       </div>

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -6,7 +6,7 @@ import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
 import { Slider } from "~/shared/components/Slider";
 
 export const SketchTool = () => {
-  const { setStrokeWidth } = useStrokeSetting();
+  const { strokeWidth, setStrokeWidth } = useStrokeSetting();
 
   return (
     <div className="flex w-56 flex-col gap-8">
@@ -18,11 +18,16 @@ export const SketchTool = () => {
         </Section>
         <Section>
           <SectionTitle>線の太さ</SectionTitle>
-          <Slider
-            min={1}
-            max={10}
-            onValueChange={(value) => setStrokeWidth(value[0])}
-          />
+          <div className="flex w-full items-center justify-center gap-2">
+            <Slider
+              min={1}
+              max={10}
+              value={[strokeWidth]}
+              onValueChange={(value) => setStrokeWidth(value[0])}
+            />
+            {/* レイアウト崩れを防ぐためにw-1を指定する */}
+            <p className="w-1 text-gray-200">{strokeWidth}</p>
+          </div>
         </Section>
       </div>
     </div>

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -9,8 +9,8 @@ export const SketchTool = () => {
   const { strokeWidth, setStrokeWidth } = useStrokeSetting();
 
   const handleStorkeWidthChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    // 太さは0未満にはできない
-    const value = Math.min(0, Number(event.target.value));
+    // 太さは1未満にはできない
+    const value = Math.max(1, Number(event.target.value));
 
     setStrokeWidth(value);
   };

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -3,10 +3,10 @@ import type { FC, ReactNode } from "react";
 import { SketchColorPicker } from "./SketchColorPicker";
 
 import { Input } from "~/shared/components/Input";
-import { useColorPicker } from "~/shared/hooks/useColorPicker";
+import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
 
 export const SketchTool = () => {
-  const { strokeWidth, setStrokeWidth } = useColorPicker();
+  const { strokeWidth, setStrokeWidth } = useStrokeSetting();
 
   return (
     <div className="flex w-56 flex-col gap-8">

--- a/frontend/src/features/sketches/SketchTool.tsx
+++ b/frontend/src/features/sketches/SketchTool.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from "react";
+import type { ChangeEventHandler, FC, ReactNode } from "react";
 
 import { SketchColorPicker } from "./SketchColorPicker";
 
@@ -7,6 +7,13 @@ import { useStrokeSetting } from "~/shared/hooks/useStrokeSetting";
 
 export const SketchTool = () => {
   const { strokeWidth, setStrokeWidth } = useStrokeSetting();
+
+  const handleStorkeWidthChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    // 太さは0未満にはできない
+    const value = Math.min(0, Number(event.target.value));
+
+    setStrokeWidth(value);
+  };
 
   return (
     <div className="flex w-56 flex-col gap-8">
@@ -18,7 +25,12 @@ export const SketchTool = () => {
         </Section>
         <Section>
           <SectionTitle>線の太さ</SectionTitle>
-          <Input className="w-full" type="number" value={strokeWidth} onChange={(event) => setStrokeWidth(Number(event.target.value))} />
+          <Input
+            className="w-full"
+            type="number"
+            value={strokeWidth}
+            onChange={handleStorkeWidthChange}
+          />
         </Section>
       </div>
     </div>

--- a/frontend/src/shared/components/Input.tsx
+++ b/frontend/src/shared/components/Input.tsx
@@ -1,9 +1,10 @@
+import classNames from "classnames";
 import { forwardRef, type InputHTMLAttributes } from "react";
 
 type Props = InputHTMLAttributes<HTMLInputElement>
 
-export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
-    return <input ref={ref} className="border border-border p-2" {...props} />;
+export const Input = forwardRef<HTMLInputElement, Props>(({ className, ...props }, ref) => {
+    return <input ref={ref} className={classNames("border rounded border-border p-2 w-full", className)} {...props} />;
   },
 );
 

--- a/frontend/src/shared/components/Slider.tsx
+++ b/frontend/src/shared/components/Slider.tsx
@@ -1,0 +1,25 @@
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import classNames from "classnames";
+import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from "react";
+
+export const Slider = forwardRef<
+  ElementRef<typeof SliderPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    max={100}
+    className={classNames(
+      "relative flex w-full touch-none select-none items-center",
+      className,
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-border">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block size-5 rounded-full border-2 border-primary bg-gray-200 ring-offset-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+
+Slider.displayName = SliderPrimitive.Root.displayName;

--- a/frontend/src/shared/hooks/useCanvas.ts
+++ b/frontend/src/shared/hooks/useCanvas.ts
@@ -1,13 +1,13 @@
 import type { RefObject } from "react";
 
-import { useColorPicker } from "./useColorPicker";
+import { useStrokeSetting } from "./useStrokeSetting";
 
 type Args = {
   canvasRef: RefObject<HTMLCanvasElement>;
 }
 
 export const useCanvas = ({ canvasRef }: Args) => {
-  const { strokeColor, strokeWidth } = useColorPicker();
+  const { strokeColor, strokeWidth } = useStrokeSetting();
 
   const getContext = (): CanvasRenderingContext2D => {
     if (!canvasRef.current) {

--- a/frontend/src/shared/hooks/useCanvas.ts
+++ b/frontend/src/shared/hooks/useCanvas.ts
@@ -7,7 +7,7 @@ type Args = {
 }
 
 export const useCanvas = ({ canvasRef }: Args) => {
-  const { strokeColor } = useColorPicker();
+  const { strokeColor, strokeWidth } = useColorPicker();
 
   const getContext = (): CanvasRenderingContext2D => {
     if (!canvasRef.current) {
@@ -19,8 +19,8 @@ export const useCanvas = ({ canvasRef }: Args) => {
       throw new Error("Failed to get 2d context");
     }
 
-    // 線の色を指定する
-    ctx.strokeStyle = strokeColor;
+    ctx.strokeStyle = strokeColor; // 線の色を指定する
+    ctx.lineWidth = strokeWidth; // 線の太さを指定する
 
     return ctx;
   };

--- a/frontend/src/shared/hooks/useColorPicker.ts
+++ b/frontend/src/shared/hooks/useColorPicker.ts
@@ -1,9 +1,11 @@
 import { atom, useAtom } from "jotai";
 
 const strokeColorAtom = atom<string>("black");
+const strokeWidthAtom = atom<number>(1);
 
 export const useColorPicker = () => {
   const [strokeColor, setStrokeColor] = useAtom(strokeColorAtom);
+  const [strokeWidth, setStrokeWidth] = useAtom(strokeWidthAtom);
 
-  return { strokeColor, setStrokeColor };
+  return { strokeColor, strokeWidth, setStrokeColor, setStrokeWidth };
 };

--- a/frontend/src/shared/hooks/useStrokeSetting.ts
+++ b/frontend/src/shared/hooks/useStrokeSetting.ts
@@ -3,7 +3,7 @@ import { atom, useAtom } from "jotai";
 const strokeColorAtom = atom<string>("black");
 const strokeWidthAtom = atom<number>(1);
 
-export const useColorPicker = () => {
+export const useStrokeSetting = () => {
   const [strokeColor, setStrokeColor] = useAtom(strokeColorAtom);
   const [strokeWidth, setStrokeWidth] = useAtom(strokeWidthAtom);
 


### PR DESCRIPTION
## 概要

<!-- このPRの変更を簡単に説明してください -->

スケッチを描く際に線の太さを指定できるようにします。

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

<img width="1272" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team1/assets/44804976/a0a114d0-16f3-4a74-b8fd-1b24b37b85c6">


## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

新たに`shadcn-ui/slider`を導入したので`npm i`を実行してください

- 太さを指定してスケッチを描けること
- ↑のスケッチがトップ画面で閲覧できること

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #189 
- Closes #199 
