### PR TITLE
画像投稿ボタンを連打できないように変更

### DIFF
--- a/frontend/src/features/sketches/SketchCreateForm/SketchCreateForm.tsx
+++ b/frontend/src/features/sketches/SketchCreateForm/SketchCreateForm.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useState, useRef } from "react";
 
 import { useSketchCreateForm } from "./useSketchCreateForm";
 
@@ -11,6 +11,13 @@ export const SketchCreateForm = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { clearCanvas } = useCanvas({ canvasRef });
   const { createSketch } = useSketchCreateForm({ canvasRef });
+  const [isSubmitting, setIsSubmitting] = useState(false); 
+
+  const handleCreateSketch = async () => {
+    setIsSubmitting(true);
+    await createSketch();
+    setIsSubmitting(false);
+  };
 
   return (
     <div className="flex">
@@ -20,7 +27,7 @@ export const SketchCreateForm = () => {
         </div>
         <div className="flex gap-2">
           <Button className="w-full" variant="secondary" onClick={clearCanvas}>リセットする</Button>
-          <Button className="w-full" onClick={createSketch}>投稿する</Button>
+          <Button className="w-full" onClick={handleCreateSketch} disabled={isSubmitting}>投稿する</Button>
         </div>
       </div>
 

--- a/frontend/src/features/sketches/SketchCreateForm/useSketchCreateForm.ts
+++ b/frontend/src/features/sketches/SketchCreateForm/useSketchCreateForm.ts
@@ -25,7 +25,7 @@ export const useSketchCreateForm = ({ canvasRef }: Args) => {
   };
 
   const createSketch = async () => {
-    const showAlert = () => console.log("投稿に失敗しました");
+    const showAlert = () => window.alert("投稿に失敗しました");
     const file = await convertCanvasToFile();
     try {
       const result = await sketchApi.postSketch(file);
@@ -34,12 +34,10 @@ export const useSketchCreateForm = ({ canvasRef }: Args) => {
         navigate("/");
       } else {
         showAlert();
-        console.error("スケッチの投稿に失敗しました");
       }
 
     } catch (error) {
       showAlert();
-      console.error(error);
     }
   };
 

--- a/frontend/src/features/sketches/SketchCreateForm/useSketchCreateForm.ts
+++ b/frontend/src/features/sketches/SketchCreateForm/useSketchCreateForm.ts
@@ -25,14 +25,22 @@ export const useSketchCreateForm = ({ canvasRef }: Args) => {
   };
 
   const createSketch = async () => {
+    const showAlert = () => console.log("投稿に失敗しました");
     const file = await convertCanvasToFile();
-    const result = await sketchApi.postSketch(file);
+    try {
+      const result = await sketchApi.postSketch(file);
 
-    if (result.status !== 201) {
-      throw new Error("画像のアップロードに失敗しました");
+      if (result.status === 201) {
+        navigate("/");
+      } else {
+        showAlert();
+        console.error("スケッチの投稿に失敗しました");
+      }
+
+    } catch (error) {
+      showAlert();
+      console.error(error);
     }
-
-    navigate("/sketches");
   };
 
   return { createSketch };


### PR DESCRIPTION
## 概要

画像投稿画面において、画像投稿ボタンを押すと、レスポンスが返ってくるまでボタンが無効になる
その後、投稿に成功すると、一覧画面に遷移する
投稿に失敗するとalertで「投稿に失敗しました」と表示され、画面は遷移しないがもう一度ボタンを押すことができる

<!-- このPRの変更を簡単に説明してください -->

## スクリーンショット

<!-- 
スクリーンショットはオプションです 
フロントエンドで作成したUIのスクリーンショットなど、
レビューの参考になる画像を必要に応じて添付してください
-->

## レビューの観点

<!-- 
どのような観点でレビューしてほしいか記載してください 
実装時に不安に思ったことや理解が曖昧な点を書いておくと重点的にレビューしやすいです
-->

## 解決するIssue

<!-- このPRで解決するIssue番号を指定してください -->

- Closes #198 
